### PR TITLE
Changes the order in which the broadcast is called. Thus the return to t...

### DIFF
--- a/src/route-segment.js
+++ b/src/route-segment.js
@@ -254,8 +254,6 @@ mod.provider( '$routeSegment',
 
                                 if(result.success != undefined) {
 
-                                    broadcast(result.success);
-
                                     for(var j = updates[i].index + 1; j < $routeSegment.chain.length; j++) {
 
                                         if($routeSegment.chain[j]) {
@@ -263,6 +261,8 @@ mod.provider( '$routeSegment',
                                             updateSegment(j, null);
                                         }
                                     }
+                                    broadcast(result.success);
+
                                 }
                             })
                         })(i);


### PR DESCRIPTION
Changes the order in which the broadcast is called. Thus the return to the Controller happens after completion and changes the url (segment).
Without this change, segments with subsegments can present problems since returning to the Controller before correcting the segment altogether. 
example:
I have 2 segments that I want to access: "section1.edit" and "section2".
I called the segment "section1.edit" and now i desire access the segment "section2". At this moment, the function returns to the Controller before changes of the chain elements, ie, returns to Controller while it is still segment "section2.edit" and not only "section2".
The broadcast makes return ahead of time, because the url changes happen after the execution of broadcast. 
