### PR TITLE
Move dev dependencies into the correct block.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "angular-route-segment",
     "version": "1.4.0",
-    "dependencies": {
+    "devDependencies": {
         "grunt": "",
         "grunt-contrib-uglify": "",
         "grunt-contrib-concat": "",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "karma-junit-reporter": "",
         "grunt-git-describe": ""
     },
+    "main": "build/angular-route-segment.js",
     "scripts": {
         "test": "grunt karma"
     }


### PR DESCRIPTION
The build dependencies were part of the npm dependencies. If this module is used as a npm dependency, the whole list of dev dependencies is added as well. This PR fixes that.
Also adds the `main` property to the package.json