### PR TITLE
Fixes #106

### DIFF
--- a/src/route-segment.js
+++ b/src/route-segment.js
@@ -264,6 +264,10 @@ mod.provider( '$routeSegment',
                                     for(var j = updates[i].index + 1; j < $routeSegment.chain.length; j++) {
 
                                         if($routeSegment.chain[j]) {
+                                            if ($routeSegment.chain[j].clearWatcher) {
+                                                $routeSegment.chain[j].clearWatcher();
+                                            }
+                                            
                                             $routeSegment.chain[j] = null;
                                             updateSegment(j, null);
                                         }


### PR DESCRIPTION
Fixes #106 

  Remove clearWatcher on any segments that get set to null so they don't
  remain in the $rootScope.$$watchers list.