### PR TITLE
Adding license info

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "angular-route-segment",
   "version": "1.5.1",
+  "license": "MIT", 
   "main": "build/angular-route-segment.js",
   "ignore": [
     "**/.*",

--- a/license.txt
+++ b/license.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2013 Artem Chivchalov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
To fix add a New Bower WebJar failed!
All attempts to determine an acceptable license have been exhausted. The bower.json file did not contain a spec-compliant license definition and the license could not be determined by trolling through the source repo: https://github.com/artch/angular-route-segment